### PR TITLE
Preview

### DIFF
--- a/menu/config.json
+++ b/menu/config.json
@@ -5,10 +5,6 @@
       "link": "/"
     },
     {
-      "name": "Saturday's Game",
-      "link": "/pages/gameday"
-    },
-    {
       "name": "On-Demand",
       "link": "/on-demand"
     },

--- a/menu/config.json
+++ b/menu/config.json
@@ -9,6 +9,10 @@
       "link": "/on-demand"
     },
     {
+      "name": "2024 Football Schedule",
+      "link": "/pages/2024-football-schedule"
+    },
+    {
       "name": "Accelerating Brilliance",
       "link": "/pages/accelerating-brilliance"
     },


### PR DESCRIPTION
Added HBCU GO Football Schedule to the primary nav. 

Name - 2024 Football Schedule
Slug - 2024-football-schedule
URL - hbcugo.tv/pages/2024-football-schedule